### PR TITLE
Double OwO throughput

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -14,9 +14,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 7.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/Owoify.Net.csproj
+++ b/Owoify.Net.csproj
@@ -12,7 +12,7 @@
     <PackageTags>C#, .NET, .NET Core, owoify, fun, funny, nonsensical, nonsense, curse, cursed, baby, babyspeak</PackageTags>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Version>1.2.0</Version>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>net7.0;netstandard2.1</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageVersion>1.2.0</PackageVersion>
     <Title>Owoify.Net</Title>

--- a/OwoifyNetTest/OwoifyNetTest.csproj
+++ b/OwoifyNetTest/OwoifyNetTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Presets.cs
+++ b/Presets.cs
@@ -1,31 +1,30 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace Owoify
 {
     internal static partial class Utility
     {
-        internal static IEnumerable<Func<Word, Word>> SpecificWordMappingList => new List<Func<Word, Word>>
+        internal static readonly Func<Word, Word>[] SpecificWordMappingList = new Func<Word, Word>[]
             {
                 MapFucToFwuc, MapMomToMwom, MapTimeToTim, MapMeToMwe,
                 MapNVowelToNy, MapOverToOwor, MapOveToUv, MapHahaToHehexD,
                 MapTheToTeh, MapYouToU, MapReadToWead, MapWorseToWose
             };
 
-        internal static IEnumerable<Func<Word, Word>> UvuMappingList => new List<Func<Word, Word>>
+        internal static readonly Func<Word, Word>[] UvuMappingList = new Func<Word, Word>[]
             {
                 MapOToOwO, MapEwToUwU, MapHeyToHay, MapDeadToDed,
                 MapNVowelTToNd
             };
 
-        internal static IEnumerable<Func<Word, Word>> UwuMappingList => new List<Func<Word, Word>>
+        internal static readonly Func<Word, Word>[] UwuMappingList = new Func<Word, Word>[]
             {
                 MapBracketsToStarTrails, MapPeriodCommaExclamationSemicolonToKaomojis,
                 MapThatToDat, MapThToF, MapLeToWal, MapVeToWe, MapRyToWwy,
                 MapROrLToW
             };
 
-        internal static IEnumerable<Func<Word, Word>> OwoMappingList => new List<Func<Word, Word>>
+        internal static readonly Func<Word, Word>[] OwoMappingList = new Func<Word, Word>[]
             {
                 MapLlToWw, MapVowelOrRExceptOlToWl, MapOldToOwld,
                 MapOlToOwl, MapLOrRoToWo, MapSpecificConsonantsOToLetterAndWo,

--- a/Utility.cs
+++ b/Utility.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 
 namespace Owoify
 {
@@ -8,18 +7,17 @@ namespace Owoify
         internal static IEnumerable<T> InterleaveArrays<T>(IEnumerable<T> a, IEnumerable<T> b)
         {
             var arr = new List<T>();
-            var observed = a.ToList();
-            var other = b.ToList();
+            var observed = a.GetEnumerator();
+            var other = b.GetEnumerator();
 
-            while (observed.Any())
+            while (observed.MoveNext())
             {
-                arr.Add(observed[0]);
-                observed.RemoveAt(0);
+                arr.Add(observed.Current);
                 (observed, other) = (other, observed);
             }
 
-            if (other.Count > 0)
-                arr = arr.Concat(other).ToList();
+            while (other.MoveNext())
+                arr.Add(other.Current);
             return arr;
         }
     }

--- a/WordMappingFunctions.cs
+++ b/WordMappingFunctions.cs
@@ -13,6 +13,188 @@ namespace Owoify
             "(/ =ω=)/", "(╯°□°）╯︵ ┻━┻", "┬─┬ ノ( ゜-゜ノ)", "¯\\_(ツ)_/¯",
         };
 
+#if NET7_0_OR_GREATER
+        [GeneratedRegex(@"o")]
+        private static partial Regex OToOwOM();
+        private static readonly Regex OToOwO = OToOwOM();
+        [GeneratedRegex(@"ew")]
+        private static partial Regex EwToUwUM();
+        private static readonly Regex EwToUwU = EwToUwUM();
+        [GeneratedRegex(@"([Hh])ey")]
+        private static partial Regex HeyToHayM();
+        private static readonly Regex HeyToHay = HeyToHayM();
+        [GeneratedRegex(@"Dead")]
+        private static partial Regex DeadToDedUpperM();
+        private static readonly Regex DeadToDedUpper = DeadToDedUpperM();
+        [GeneratedRegex(@"dead")]
+        private static partial Regex DeadToDedLowerM();
+        private static readonly Regex DeadToDedLower = DeadToDedLowerM();
+        [GeneratedRegex(@"n[aeiou]*t")]
+        private static partial Regex NVowelTToNdM();
+        private static readonly Regex NVowelTToNd = NVowelTToNdM();
+        [GeneratedRegex(@"Read")]
+        private static partial Regex ReadToWeadUpperM();
+        private static readonly Regex ReadToWeadUpper = ReadToWeadUpperM();
+        [GeneratedRegex(@"read")]
+        private static partial Regex ReadToWeadLowerM();
+        private static readonly Regex ReadToWeadLower = ReadToWeadLowerM();
+        [GeneratedRegex(@"[({<]")]
+        private static partial Regex BracketsToStarTrailsForeM();
+        private static readonly Regex BracketsToStarTrailsFore = BracketsToStarTrailsForeM();
+        [GeneratedRegex(@"[)}>]")]
+        private static partial Regex BracketsToStarTrailsRearM();
+        private static readonly Regex BracketsToStarTrailsRear = BracketsToStarTrailsRearM();
+        [GeneratedRegex(@"[.,](?![0-9])")]
+        private static partial Regex PeriodCommaExclamationSemicolonToKaomojisFirstM();
+        private static readonly Regex PeriodCommaExclamationSemicolonToKaomojisFirst = PeriodCommaExclamationSemicolonToKaomojisFirstM();
+        [GeneratedRegex(@"[!;]+")]
+        private static partial Regex PeriodCommaExclamationSemicolonToKaomojisSecondM();
+        private static readonly Regex PeriodCommaExclamationSemicolonToKaomojisSecond = PeriodCommaExclamationSemicolonToKaomojisSecondM();
+        [GeneratedRegex(@"that")]
+        private static partial Regex ThatToDatLowerM();
+        private static readonly Regex ThatToDatLower = ThatToDatLowerM();
+        [GeneratedRegex(@"That")]
+        private static partial Regex ThatToDatUpperM();
+        private static readonly Regex ThatToDatUpper = ThatToDatUpperM();
+        [GeneratedRegex(@"[Tt]h(?![Ee])")]
+        private static partial Regex ThToFLowerM();
+        private static readonly Regex ThToFLower = ThToFLowerM();
+        [GeneratedRegex(@"TH(?!E)")]
+        private static partial Regex ThToFUpperM();
+        private static readonly Regex ThToFUpper = ThToFUpperM();
+        [GeneratedRegex(@"le$")]
+        private static partial Regex LeToWalM();
+        private static readonly Regex LeToWal = LeToWalM();
+        [GeneratedRegex(@"ve")]
+        private static partial Regex VeToWeLowerM();
+        private static readonly Regex VeToWeLower = VeToWeLowerM();
+        [GeneratedRegex(@"Ve")]
+        private static partial Regex VeToWeUpperM();
+        private static readonly Regex VeToWeUpper = VeToWeUpperM();
+        [GeneratedRegex(@"ry")]
+        private static partial Regex RyToWwyM();
+        private static readonly Regex RyToWwy = RyToWwyM();
+        [GeneratedRegex(@"(?:r|l)")]
+        private static partial Regex ROrLToWLowerM();
+        private static readonly Regex ROrLToWLower = ROrLToWLowerM();
+        [GeneratedRegex(@"(?:R|L)")]
+        private static partial Regex ROrLToWUpperM();
+        private static readonly Regex ROrLToWUpper = ROrLToWUpperM();
+        [GeneratedRegex(@"ll")]
+        private static partial Regex LlToWwM();
+        private static readonly Regex LlToWw = LlToWwM();
+        [GeneratedRegex(@"[aeiur]l$")]
+        private static partial Regex VowelOrRExceptOlToWlLowerM();
+        private static readonly Regex VowelOrRExceptOlToWlLower = VowelOrRExceptOlToWlLowerM();
+        [GeneratedRegex(@"[AEIUR]([lL])$")]
+        private static partial Regex VowelOrRExceptOlToWlUpperM();
+        private static readonly Regex VowelOrRExceptOlToWlUpper = VowelOrRExceptOlToWlUpperM();
+        [GeneratedRegex(@"([Oo])ld")]
+        private static partial Regex OldToOwldLowerM();
+        private static readonly Regex OldToOwldLower = OldToOwldLowerM();
+        [GeneratedRegex(@"OLD")]
+        private static partial Regex OldToOwldUpperM();
+        private static readonly Regex OldToOwldUpper = OldToOwldUpperM();
+        [GeneratedRegex(@"([Oo])l")]
+        private static partial Regex OlToOwlLowerM();
+        private static readonly Regex OlToOwlLower = OlToOwlLowerM();
+        [GeneratedRegex(@"OL")]
+        private static partial Regex OlToOwlUpperM();
+        private static readonly Regex OlToOwlUpper = OlToOwlUpperM();
+        [GeneratedRegex(@"[lr]o")]
+        private static partial Regex LOrRoToWoLowerM();
+        private static readonly Regex LOrRoToWoLower = LOrRoToWoLowerM();
+        [GeneratedRegex(@"[LR]([oO])")]
+        private static partial Regex LOrRoToWoUpperM();
+        private static readonly Regex LOrRoToWoUpper = LOrRoToWoUpperM();
+        [GeneratedRegex(@"([bcdfghjkmnpqstxyz])o")]
+        private static partial Regex SpecificConsonantsOToLetterAndWoLowerM();
+        private static readonly Regex SpecificConsonantsOToLetterAndWoLower = SpecificConsonantsOToLetterAndWoLowerM();
+        [GeneratedRegex(@"([BCDFGHJKMNPQSTXYZ])([oO])")]
+        private static partial Regex SpecificConsonantsOToLetterAndWoUpperM();
+        private static readonly Regex SpecificConsonantsOToLetterAndWoUpper = SpecificConsonantsOToLetterAndWoUpperM();
+        [GeneratedRegex(@"[vw]le")]
+        private static partial Regex VOrWLeToWalM();
+        private static readonly Regex VOrWLeToWal = VOrWLeToWalM();
+        [GeneratedRegex(@"([Ff])i")]
+        private static partial Regex FiToFwiLowerM();
+        private static readonly Regex FiToFwiLower = FiToFwiLowerM();
+        [GeneratedRegex(@"FI")]
+        private static partial Regex FiToFwiUpperM();
+        private static readonly Regex FiToFwiUpper = FiToFwiUpperM();
+        [GeneratedRegex(@"([Vv])er")]
+        private static partial Regex VerToWerM();
+        private static readonly Regex VerToWer = VerToWerM();
+        [GeneratedRegex(@"([Pp])oi")]
+        private static partial Regex PoiToPwoiM();
+        private static readonly Regex PoiToPwoi = PoiToPwoiM();
+        [GeneratedRegex(@"([DdFfGgHhJjPpQqRrSsTtXxYyZz])le$")]
+        private static partial Regex SpecificConsonantsLeToLetterAndWalM();
+        private static readonly Regex SpecificConsonantsLeToLetterAndWal = SpecificConsonantsLeToLetterAndWalM();
+        [GeneratedRegex(@"([BbCcDdFfGgKkPpQqSsTtWwXxZz])r")]
+        private static partial Regex ConsonantRToConsonantWM();
+        private static readonly Regex ConsonantRToConsonantW = ConsonantRToConsonantWM();
+        [GeneratedRegex(@"ly")]
+        private static partial Regex LyToWyLowerM();
+        private static readonly Regex LyToWyLower = LyToWyLowerM();
+        [GeneratedRegex(@"Ly")]
+        private static partial Regex LyToWyUpperM();
+        private static readonly Regex LyToWyUpper = LyToWyUpperM();
+        [GeneratedRegex(@"([Pp])le")]
+        private static partial Regex PleToPweM();
+        private static readonly Regex PleToPwe = PleToPweM();
+        [GeneratedRegex(@"nr")]
+        private static partial Regex NrToNwLowerM();
+        private static readonly Regex NrToNwLower = NrToNwLowerM();
+        [GeneratedRegex(@"NR")]
+        private static partial Regex NrToNwUpperM();
+        private static readonly Regex NrToNwUpper = NrToNwUpperM();
+        [GeneratedRegex(@"([Ff])uc")]
+        private static partial Regex FucToFwucM();
+        private static readonly Regex FucToFwuc = FucToFwucM();
+        [GeneratedRegex(@"([Mm])om")]
+        private static partial Regex MomToMwomM();
+        private static readonly Regex MomToMwom = MomToMwomM();
+        [GeneratedRegex(@"([Mm])e")]
+        private static partial Regex MeToMweM();
+        private static readonly Regex MeToMwe = MeToMweM();
+        [GeneratedRegex(@"n([aeiou])")]
+        private static partial Regex NVowelToNyFirstM();
+        private static readonly Regex NVowelToNyFirst = NVowelToNyFirstM();
+        [GeneratedRegex(@"N([aeiou])")]
+        private static partial Regex NVowelToNySecondM();
+        private static readonly Regex NVowelToNySecond = NVowelToNySecondM();
+        [GeneratedRegex(@"N([AEIOU])")]
+        private static partial Regex NVowelToNyThirdM();
+        private static readonly Regex NVowelToNyThird = NVowelToNyThirdM();
+        [GeneratedRegex(@"ove")]
+        private static partial Regex OveToUvLowerM();
+        private static readonly Regex OveToUvLower = OveToUvLowerM();
+        [GeneratedRegex(@"OVE")]
+        private static partial Regex OveToUvUpperM();
+        private static readonly Regex OveToUvUpper = OveToUvUpperM();
+        [GeneratedRegex(@"\b(ha|hah|heh|hehe)+\b")]
+        private static partial Regex HahaToHehexDM();
+        private static readonly Regex HahaToHehexD = HahaToHehexDM();
+        [GeneratedRegex(@"\b([Tt])he\b")]
+        private static partial Regex TheToTehM();
+        private static readonly Regex TheToTeh = TheToTehM();
+        [GeneratedRegex(@"\bYou\b")]
+        private static partial Regex YouToUUpperM();
+        private static readonly Regex YouToUUpper = YouToUUpperM();
+        [GeneratedRegex(@"\byou\b")]
+        private static partial Regex YouToULowerM();
+        private static readonly Regex YouToULower = YouToULowerM();
+        [GeneratedRegex(@"\b([Tt])ime\b")]
+        private static partial Regex TimeToTimM();
+        private static readonly Regex TimeToTim = TimeToTimM();
+        [GeneratedRegex(@"([Oo])ver")]
+        private static partial Regex OverToOworM();
+        private static readonly Regex OverToOwor = OverToOworM();
+        [GeneratedRegex(@"([Ww])orse")]
+        private static partial Regex WorseToWoseM();
+        private static readonly Regex WorseToWose = WorseToWoseM();
+#else
         private static readonly Regex OToOwO = new Regex(@"o");
         private static readonly Regex EwToUwU = new Regex(@"ew");
         private static readonly Regex HeyToHay = new Regex(@"([Hh])ey");
@@ -73,6 +255,7 @@ namespace Owoify
         private static readonly Regex TimeToTim = new Regex(@"\b([Tt])ime\b");
         private static readonly Regex OverToOwor = new Regex(@"([Oo])ver");
         private static readonly Regex WorseToWose = new Regex(@"([Ww])orse");
+#endif
 
         private static Word MapOToOwO(Word input)
             => input.Replace(OToOwO, 


### PR DESCRIPTION
Summary of changes:
- Library and tests projects now also target `net7.0`
- The regexes in `WordMappingFunctions.cs` and `Program.cs` are now [source generated](https://learn.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-source-generators) if targeting .NET 7.0 or greater
- Initialize presets as array and store them as such, to allow the compiler to optimize foreaches to not use enumerators but instead a for loop
- in `Program.cs` use foreaches instead of LINQ's Aggregate
- the `InterleaveArrays` function in `Utility.cs` now doesn't convert `a` and `b` into a List, instead it just uses their enumerators
- In `Word.cs`:
  - moved some if statements up in the code to return early because we can(prevents unnecessary code being run)
  - if targeting .NET 7.0 or greater `EnumerateMatches` on a regex is now used
  - changed `.Select(x => x.Value.Replace(x.Value, replaceValue))` to `.Select(x => replaceValue)`
  - `SearchValueContainsReplacedWords` uses a foreach loop instead of LINQ's `Any`
- also updated Github Actions to use .NET 7.0

All these changes add up to a doubling of owo throughput and allocations down to a fifth when benchmarking with the string `Hello World! This is the string to owo! Kinda cute, isn't it?`.
The benchmarks with `/p:NewOwo=true` are with this PR's modifications.

```
BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.25300.1000)
Intel Core i7-10750H CPU 2.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET SDK=7.0.202
  [Host]     : .NET 7.0.4 (7.0.423.11508), X64 RyuJIT AVX2
  Job-IEXBAN : .NET 6.0.14 (6.0.1423.7309), X64 RyuJIT AVX2
  Job-CAAAOX : .NET 6.0.14 (6.0.1423.7309), X64 RyuJIT AVX2
  Job-YYXTLU : .NET 7.0.4 (7.0.423.11508), X64 RyuJIT AVX2
  Job-SYLWUH : .NET 7.0.4 (7.0.423.11508), X64 RyuJIT AVX2
```

|       Method |  Runtime |      Arguments | level |      Mean |    Error |   StdDev | Ratio | RatioSD | Allocated | Alloc Ratio |
|------------- |--------- |--------------- |------ |----------:|---------:|---------:|------:|--------:|----------:|------------:|
| ShortMessage | .NET 6.0 | /p:NewOwo=true |   Owo |  57.54 us | 0.999 us | 1.299 us |  0.46 |    0.02 |  30.17 KB |        0.17 |
| ShortMessage | .NET 6.0 |        Default |   Owo | 124.02 us | 2.472 us | 3.215 us |  1.00 |    0.00 | 174.17 KB |        1.00 |
| ShortMessage | .NET 7.0 | /p:NewOwo=true |   Owo |  58.54 us | 1.087 us | 1.488 us |  0.47 |    0.02 |  28.05 KB |        0.16 |
| ShortMessage | .NET 7.0 |        Default |   Owo | 135.72 us | 2.692 us | 4.347 us |  1.09 |    0.05 | 174.02 KB |        1.00 |
|              |          |                |       |           |          |          |       |         |           |             |
| ShortMessage | .NET 6.0 | /p:NewOwo=true |   Uwu |  98.23 us | 1.949 us | 2.917 us |  0.52 |    0.02 |  46.68 KB |        0.20 |
| ShortMessage | .NET 6.0 |        Default |   Uwu | 189.66 us | 3.751 us | 6.570 us |  1.00 |    0.00 | 237.11 KB |        1.00 |
| ShortMessage | .NET 7.0 | /p:NewOwo=true |   Uwu | 105.97 us | 2.086 us | 2.855 us |  0.56 |    0.03 |  40.49 KB |        0.17 |
| ShortMessage | .NET 7.0 |        Default |   Uwu | 217.25 us | 4.246 us | 7.869 us |  1.15 |    0.06 | 236.95 KB |        1.00 |
|              |          |                |       |           |          |          |       |         |           |             |
| ShortMessage | .NET 6.0 | /p:NewOwo=true |   Uvu | 122.55 us | 2.421 us | 5.706 us |  0.54 |    0.03 |  53.26 KB |        0.20 |
| ShortMessage | .NET 6.0 |        Default |   Uvu | 229.16 us | 4.478 us | 8.628 us |  1.00 |    0.00 |  266.8 KB |        1.00 |
| ShortMessage | .NET 7.0 | /p:NewOwo=true |   Uvu | 136.14 us | 2.708 us | 4.813 us |  0.59 |    0.02 |  44.83 KB |        0.17 |
| ShortMessage | .NET 7.0 |        Default |   Uvu | 250.58 us | 4.863 us | 9.484 us |  1.10 |    0.06 | 266.64 KB |        1.00 |